### PR TITLE
do not delete folder immediately when pushing delete

### DIFF
--- a/Resources/views/Folder/show.html.twig
+++ b/Resources/views/Folder/show.html.twig
@@ -10,8 +10,8 @@
                 <a href="{{ path('KunstmaanMediaBundle_media_create', { 'folderId' : folder.id, 'type': addaction.type }) }}" class="btn {% if loop.first %}btn-primary{% endif %}">{{ addaction.name |trans }}</a>
             {% endfor %}
             <a href="{{ path('KunstmaanMediaBundle_media_bulk_upload', { 'folderId' : folder.id }) }}" class="btn">{{ 'media.bulkupload.bulkupload' |trans }}</a>
-            <a href="{{ path('KunstmaanMediaBundle_folder_sub_create', { 'folderId' : folder.id }) }}" data-toggle="modal" data-target="#addsub-modal" class="btn">{{ 'media.folder.addsub.action' |trans }}</a>
-            <a href="{{ path('KunstmaanMediaBundle_folder_delete', { 'folderId' : folder.id }) }}" data-toggle="modal" data-target="#delete-modal" class="btn">{{ 'media.folder.delete.action' |trans }}</a>
+            <a href="#" data-toggle="modal" data-target="#addsub-modal" class="btn">{{ 'media.folder.addsub.action' |trans }}</a>
+            <a href="#" data-toggle="modal" data-target="#delete-modal" class="btn">{{ 'media.folder.delete.action' |trans }}</a>
         {% endblock %}
     </div>
 


### PR DESCRIPTION
If the href={{ path to delete folder }} is set on the button, it deletes the folder immediately without asking for confirmation. Changed the href link to # to prevent this, and use the delete link from the modal.
