### PR TITLE
use public property vars and not set

### DIFF
--- a/Controller/MediaController.php
+++ b/Controller/MediaController.php
@@ -126,7 +126,7 @@ class MediaController extends Controller
 
         $formView = $form->createView();
         $filesfield = $formView->children['files'];
-        $filesfield->set('full_name', 'kunstmaan_mediabundle_bulkupload[files][]');
+        $filesfield->vars['full_name'] = 'kunstmaan_mediabundle_bulkupload[files][]';
 
         return array(
             'form'      => $formView,


### PR DESCRIPTION
The set method in Formview is Deprecated since version 2.1, to be removed in 2.3. Access the public property {@link vars} instead.
