### PR TITLE
Docs, CodingStandards & add to service for MediaCreatorService

### DIFF
--- a/Helper/Services/MediaCreatorService.php
+++ b/Helper/Services/MediaCreatorService.php
@@ -26,35 +26,41 @@ use Symfony\Component\HttpFoundation\File\File;
  * Class MediaCreatorService
  * @package Kunstmaan\MediaBundle\Helper\Services
  */
-class MediaCreatorService {
+class MediaCreatorService
+{
 
     /** @var EntityManager */
     protected $em;
     /** @var FolderRepository */
     protected $folderRepository;
 
+    /**
+     * @param EntityManager $em
+     */
     public function setEntityManager(EntityManager $em)
     {
         $this->em = $em;
         $this->folderRepository = $em->getRepository('KunstmaanMediaBundle:Folder');
     }
 
-    const CONTEXT_console = 'console';
-    const CONTEXT_web = 'web';
+    const CONTEXT_CONSOLE = 'console';
+    const CONTEXT_WEB = 'web';
 
     /**
-     * @param $filePath string The full filepath of the asset you want to upload. The filetype will be automatically detected.
+     * @param $filePath string  The full filepath of the asset you want to upload. The filetype will be automatically detected.
      * @param $folderId integer For now you still have to manually pass the correct folder ID.
-     * @param string $context This is needed because the Filesystem basepath differs between web & console application env.
+     * @param string $context   This is needed because the Filesystem basepath differs between web & console application env.
+     *
      * @return Media
      */
-    public function createFile($filePath, $folderId, $context = MediaCreatorService::CONTEXT_web) {
+    public function createFile($filePath, $folderId, $context = MediaCreatorService::CONTEXT_WEB)
+    {
         $fileHandler = new FileHandler();
 
         // Get file from FilePath.
         $data = new File($filePath, true);
 
-        if ($context == MediaCreatorService::CONTEXT_console) {
+        if ($context == MediaCreatorService::CONTEXT_CONSOLE) {
             $fileHandler->fileSystem = new Filesystem(new \Gaufrette\Adapter\Local("web/uploads/media/", true));
         }
 

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -3,6 +3,7 @@ parameters:
     kunstmaan_media.menu.adaptor.class: 'Kunstmaan\MediaBundle\Helper\Menu\MediaMenuAdaptor'
     kunstmaan_media.listener.doctrine.class: 'Kunstmaan\MediaBundle\EventListener\DoctrineMediaListener'
     kunstmaan_media.form.type.media.class: 'Kunstmaan\MediaBundle\Form\Type\MediaType'
+    kunstmaan_media.media_creator_service.class: 'Kunstmaan\MediaBundle\Helper\Services\MediaCreatorService'
 
 
 services:
@@ -13,6 +14,7 @@ services:
             - ''
         tags:
             - { name: 'liip_imagine.data.loader', loader: 'kunstmaan_media_thumbloader' }
+
     kunstmaan_media.media_manager:
         class: "%kunstmaan_media.media_manager.class%"
 
@@ -21,7 +23,7 @@ services:
         arguments: ["@doctrine.orm.entity_manager"]
         tags:
             -  { name: 'kunstmaan_admin.menu.adaptor' }
-            
+
     kunstmaan_media.listener.doctrine:
         class: "%kunstmaan_media.listener.doctrine.class%"
         arguments: ["@kunstmaan_media.media_manager"]
@@ -31,7 +33,7 @@ services:
             - { name: 'doctrine.event_listener', event: 'postPersist' }
             - { name: 'doctrine.event_listener', event: 'postUpdate' }
             - { name: 'doctrine.event_listener', event: 'preRemove' }
-            
+
     form.type.media:
         class: "%kunstmaan_media.form.type.media.class%"
         arguments:
@@ -39,3 +41,8 @@ services:
             - "@doctrine.orm.entity_manager"
         tags:
             - { name: form.type, alias: media }
+
+    kunstmaan_media.media_creator_service:
+        class: "%kunstmaan_media.media_creator_service.class%"
+        calls:
+            - [ setEntityManager, [ "@doctrine.orm.entity_manager" ] ]

--- a/Resources/doc/MediaBundle.md
+++ b/Resources/doc/MediaBundle.md
@@ -68,3 +68,19 @@ form
 ### Class:
 
 Kunstmaan\MediaBundle\Form\Type\MediaType
+
+## Uploading Media in Your Code
+
+Using the ```MediaCreatorService``` you can easily upload a media-asset to a Folder.
+
+The API is straightforward:
+
+```
+    $mediaCreatorService = $this->container->get('kunstmaan_media.media_creator_service');
+    $media = $mediaCreatorService->createFile('./app/Content/Images/placeholder.jpg', 1, MediaCreatorService::CONTEXT_CONSOLE);
+```
+
+The path is relevant to the root of your Symfony project. The context can be either web or console.
+You'll have to set this to console when you are calling the code from an environment outside of your webserver.
+For example for a migration you would use the console context. Otherwise you can just omit the parameter
+so the default web context is used.


### PR DESCRIPTION
There are 2 small breakingchanges. The constants have been fully uppercased and the getEntityManager function was removed (seemeed useless and a silly way to get to the EntityManager)

I noticed the MediaCreatorService is used in https://github.com/Kunstmaan/KunstmaanGeneratorBundle/compare/add_homepage_slider?expand=1

If this gets merged it'll have to be updated as well.
