### PR TITLE
make it possible to add the class/style attributes in media form fields

### DIFF
--- a/Resources/views/Form/formWidgets.html.twig
+++ b/Resources/views/Form/formWidgets.html.twig
@@ -1,6 +1,6 @@
 {% block media_widget %}
 {% spaceless %}
-	<div id="{{ id }}_widget" class="clearfix">
+	<div id="{{ id }}_widget" class="clearfix {{ attr.class|default('') }}" style="{{ attr.style|default('') }}">
 		<input type="hidden" name="{{ full_name }}" value="{% if(value.id is defined) %}{{ value.id }}{% endif %}"/>
 
 		<div class="input_media hasnomedia">


### PR DESCRIPTION
The class -and label attributes can be used in all other form field types, but not in the media form field type.
