### PR TITLE
Use FileBinaryMimeTypeGuesser first

### DIFF
--- a/Helper/File/FileHandler.php
+++ b/Helper/File/FileHandler.php
@@ -41,6 +41,7 @@ class FileHandler extends AbstractMediaHandler
     public function __construct()
     {
         $this->mimeTypeGuesser = MimeTypeGuesser::getInstance();
+        $this->mimeTypeGuesser->register(new FileBinaryMimeTypeGuesser());
     }
 
     /**


### PR DESCRIPTION
This solves issues on non-windows servers where the system mimetype should be used by default.
